### PR TITLE
Add log color adjust in on-http

### DIFF
--- a/lib/api/2.0/config.js
+++ b/lib/api/2.0/config.js
@@ -14,9 +14,19 @@ var configPatch = controller(function(req) {
     return config.configSet(req.body);
 });
 
+var configColorGet = controller(function(req) {
+    return config.configGetColor(req.query);
+});
+
+var configColorPut = controller(function(req) {
+    return config.configSetColor(req.body);
+});
+
 module.exports = {
     configGet: configGet,
     configPut: configPatch,
-    configPatch: configPatch
+    configPatch: configPatch,
+    configColorPut: configColorPut,
+    configColorGet: configColorGet
 };
 

--- a/lib/services/config-api-service.js
+++ b/lib/services/config-api-service.js
@@ -9,12 +9,14 @@ di.annotate(configApiServiceFactory, new di.Provide('Http.Services.Api.Config'))
 di.annotate(configApiServiceFactory,
     new di.Inject(
         'Services.Configuration',
-        '_'
+        '_',
+        'LogEvent'
     )
 );
 function configApiServiceFactory(
     configuration,
-    _
+    _,
+    LogEvent
 ) {
     function ConfigApiService() {
     }
@@ -28,6 +30,13 @@ function configApiServiceFactory(
         // get the config
 
         return configuration.getAll();
+    };
+
+    ConfigApiService.prototype.configGetColor = function () {
+        // get the config
+        
+        var val=configuration.get("logColorEnable");
+        return {enable:(val === undefined) ? false : val};
     };
 
     /**
@@ -45,6 +54,13 @@ function configApiServiceFactory(
 
         return configuration.getAll();
     };
-
+  
+    ConfigApiService.prototype.configSetColor = function(config) {
+        var value = config.enable;
+        configuration.set("color", value);
+        configuration.set("logColorEnable", value); 
+        LogEvent.setColorEnable(value); 
+        return {color:configuration.get("color"),logColoerEnable:configuration.get("logColorEnable")};
+    };
     return new ConfigApiService();
 }

--- a/static/monorail-2.0.yaml
+++ b/static/monorail-2.0.yaml
@@ -1,6 +1,6 @@
 info:
   title: rackhd api 
-  version: "5.0.0"
+  version: "4.0.0"
 basePath: /api/2.0
 consumes:
 - application/json
@@ -57,6 +57,13 @@ definitions:
     - command
   generic_obj:
     type: object
+  enable_flag:
+    description: Set enable to flag value
+    properties: 
+      enable:
+        type: boolean
+    required:
+    - enable   
   get_user_obj:
     properties:
       role:
@@ -211,12 +218,9 @@ definitions:
         type: object
       service:
         type: string
-      nodeId:
-        type: string
     required:
     - service
     - config
-    - nodeId
     type: object
   obm_led:
     properties:
@@ -607,6 +611,57 @@ paths:
           schema:
             $ref: '#/definitions/Error'
       summary: Patch server configuration
+      tags:
+      - /api/2.0
+      x-authentication-type:
+      - jwt
+      x-privileges:
+      - Write
+      - configModify
+    x-swagger-router-controller: config
+  /config/logcolor:
+    get:
+      description: Get the RackHD log color configuration properties.
+      operationId: configColorGet
+      responses:
+        200:
+          description: Successfully retrieved the log color configuration
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+      summary: Get log color configuration
+      tags:
+      - /api/2.0
+      x-authentication-type:
+      - jwt
+      x-privileges:
+      - Read
+      - configRead
+    put:
+      consumes:
+      - application/json
+      description: Modify the RackHD server log color configuration.
+      operationId: configColorPut
+      parameters:
+      - description: The configuration properties to be modified
+        in: body
+        name: configColor
+        required: true
+        schema:
+          $ref: '#/definitions/enable_flag'
+      responses:
+        200:
+          description: Successfully modified the configuration
+          schema:
+            type: object
+        default:
+          description: Unexpected error
+          schema:
+            $ref: '#/definitions/Error'
+      summary: Change log color configuration
       tags:
       - /api/2.0
       x-authentication-type:


### PR DESCRIPTION
Details:
This is a experiment PR to add a "logcolor" entry in the on-http.  It added put and get method and related service handler for this function.

Result:
![onhttp](https://user-images.githubusercontent.com/14198260/29355697-9b1def10-82a4-11e7-9d7e-1df6fc567a47.png)
![onhttp2](https://user-images.githubusercontent.com/14198260/29357567-92fac186-82aa-11e7-9200-7e8a1ea963f0.png)

